### PR TITLE
[OPAL-12292] Remove required clauses from nullable datets

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3611,7 +3611,6 @@ components:
           nullable: true
           type: string
       required:
-        - expiration_date
         - resource_id
         - status
         - user_id
@@ -3664,7 +3663,6 @@ components:
           type: string
       required:
         - email
-        - expiration_date
         - full_name
         - resource_id
         - user_id
@@ -3722,7 +3720,6 @@ components:
           type: integer
       required:
         - email
-        - expiration_date
         - full_name
         - resource_id
         - user_id
@@ -3806,7 +3803,6 @@ components:
         - principal_type
         - entity_id
         - entity_type
-        - expiration_date
         - has_direct_access
         - num_access_paths
       type: object
@@ -3841,7 +3837,6 @@ components:
       required:
         - resource_id
         - non_human_identity_id
-        - expiration_date
       type: object
     SessionsList:
       example:
@@ -4334,7 +4329,6 @@ components:
           type: string
       required:
         - email
-        - expiration_date
         - full_name
         - group_id
         - user_id

--- a/docs/Access.md
+++ b/docs/Access.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **entity_id** | **str** | The ID of the entity being accessed. | 
 **entity_type** | [**EntityTypeEnum**](EntityTypeEnum.md) |  | 
 **access_level** | [**ResourceAccessLevel**](ResourceAccessLevel.md) |  | [optional] 
-**expiration_date** | **datetime** | The day and time the principal&#39;s access will expire. | 
+**expiration_date** | **datetime** | The day and time the principal&#39;s access will expire. | [optional] 
 **has_direct_access** | **bool** | The principal has direct access to this entity (vs. inherited access). | 
 **num_access_paths** | **int** | The number of ways in which the principal has access to this entity (directly and inherited). | 
 

--- a/docs/GroupUser.md
+++ b/docs/GroupUser.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **access_level** | [**GroupAccessLevel**](GroupAccessLevel.md) |  | [optional] 
 **full_name** | **str** | The user&#39;s full name. | 
 **email** | **str** | The user&#39;s email. | 
-**expiration_date** | **datetime** | The day and time the user&#39;s access will expire. | 
+**expiration_date** | **datetime** | The day and time the user&#39;s access will expire. | [optional] 
 
 ## Example
 

--- a/docs/ResourceAccessUser.md
+++ b/docs/ResourceAccessUser.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **access_level** | [**ResourceAccessLevel**](ResourceAccessLevel.md) |  | 
 **full_name** | **str** | The user&#39;s full name. | 
 **email** | **str** | The user&#39;s email. | 
-**expiration_date** | **datetime** | The day and time the user&#39;s access will expire. | 
+**expiration_date** | **datetime** | The day and time the user&#39;s access will expire. | [optional] 
 **has_direct_access** | **bool** | The user has direct access to this resources (vs. indirectly, like through a group). | 
 **num_access_paths** | **int** | The number of ways in which the user has access through this resource (directly and indirectly). | 
 

--- a/docs/ResourceNHI.md
+++ b/docs/ResourceNHI.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **resource_id** | **str** | The ID of the resource. | 
 **non_human_identity_id** | **str** | The resource ID of the non-human identity. | 
 **access_level** | [**ResourceAccessLevel**](ResourceAccessLevel.md) |  | [optional] 
-**expiration_date** | **datetime** | The day and time the non-human identity&#39;s access will expire. | 
+**expiration_date** | **datetime** | The day and time the non-human identity&#39;s access will expire. | [optional] 
 
 ## Example
 

--- a/docs/ResourceUser.md
+++ b/docs/ResourceUser.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **access_level** | [**ResourceAccessLevel**](ResourceAccessLevel.md) |  | 
 **full_name** | **str** | The user&#39;s full name. | 
 **email** | **str** | The user&#39;s email. | 
-**expiration_date** | **datetime** | The day and time the user&#39;s access will expire. | 
+**expiration_date** | **datetime** | The day and time the user&#39;s access will expire. | [optional] 
 
 ## Example
 

--- a/docs/ResourceUserAccessStatus.md
+++ b/docs/ResourceUserAccessStatus.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **user_id** | **str** | The ID of the user. | 
 **access_level** | [**ResourceAccessLevel**](ResourceAccessLevel.md) |  | [optional] 
 **status** | [**ResourceUserAccessStatusEnum**](ResourceUserAccessStatusEnum.md) |  | 
-**expiration_date** | **datetime** | The day and time the user&#39;s access will expire. | 
+**expiration_date** | **datetime** | The day and time the user&#39;s access will expire. | [optional] 
 
 ## Example
 

--- a/opal/models/access.py
+++ b/opal/models/access.py
@@ -35,7 +35,7 @@ class Access(BaseModel):
     entity_id: StrictStr = Field(description="The ID of the entity being accessed.")
     entity_type: EntityTypeEnum
     access_level: Optional[ResourceAccessLevel] = None
-    expiration_date: datetime = Field(description="The day and time the principal's access will expire.")
+    expiration_date: Optional[datetime] = Field(default=None, description="The day and time the principal's access will expire.")
     has_direct_access: StrictBool = Field(description="The principal has direct access to this entity (vs. inherited access).")
     num_access_paths: StrictInt = Field(description="The number of ways in which the principal has access to this entity (directly and inherited).")
     additional_properties: Dict[str, Any] = {}

--- a/opal/models/group_user.py
+++ b/opal/models/group_user.py
@@ -34,7 +34,7 @@ class GroupUser(BaseModel):
     access_level: Optional[GroupAccessLevel] = None
     full_name: StrictStr = Field(description="The user's full name.")
     email: StrictStr = Field(description="The user's email.")
-    expiration_date: datetime = Field(description="The day and time the user's access will expire.")
+    expiration_date: Optional[datetime] = Field(default=None, description="The day and time the user's access will expire.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["group_id", "user_id", "access_level", "full_name", "email", "expiration_date"]
 

--- a/opal/models/resource_access_user.py
+++ b/opal/models/resource_access_user.py
@@ -20,7 +20,7 @@ import json
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from opal.models.resource_access_level import ResourceAccessLevel
 from typing import Optional, Set
 from typing_extensions import Self
@@ -34,7 +34,7 @@ class ResourceAccessUser(BaseModel):
     access_level: ResourceAccessLevel
     full_name: StrictStr = Field(description="The user's full name.")
     email: StrictStr = Field(description="The user's email.")
-    expiration_date: datetime = Field(description="The day and time the user's access will expire.")
+    expiration_date: Optional[datetime] = Field(default=None, description="The day and time the user's access will expire.")
     has_direct_access: StrictBool = Field(description="The user has direct access to this resources (vs. indirectly, like through a group).")
     num_access_paths: StrictInt = Field(description="The number of ways in which the user has access through this resource (directly and indirectly).")
     additional_properties: Dict[str, Any] = {}

--- a/opal/models/resource_nhi.py
+++ b/opal/models/resource_nhi.py
@@ -32,7 +32,7 @@ class ResourceNHI(BaseModel):
     resource_id: StrictStr = Field(description="The ID of the resource.")
     non_human_identity_id: StrictStr = Field(description="The resource ID of the non-human identity.")
     access_level: Optional[ResourceAccessLevel] = None
-    expiration_date: datetime = Field(description="The day and time the non-human identity's access will expire.")
+    expiration_date: Optional[datetime] = Field(default=None, description="The day and time the non-human identity's access will expire.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["resource_id", "non_human_identity_id", "access_level", "expiration_date"]
 

--- a/opal/models/resource_user.py
+++ b/opal/models/resource_user.py
@@ -20,7 +20,7 @@ import json
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from opal.models.resource_access_level import ResourceAccessLevel
 from typing import Optional, Set
 from typing_extensions import Self
@@ -34,7 +34,7 @@ class ResourceUser(BaseModel):
     access_level: ResourceAccessLevel
     full_name: StrictStr = Field(description="The user's full name.")
     email: StrictStr = Field(description="The user's email.")
-    expiration_date: datetime = Field(description="The day and time the user's access will expire.")
+    expiration_date: Optional[datetime] = Field(default=None, description="The day and time the user's access will expire.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["resource_id", "user_id", "access_level", "full_name", "email", "expiration_date"]
 

--- a/opal/models/resource_user_access_status.py
+++ b/opal/models/resource_user_access_status.py
@@ -34,7 +34,7 @@ class ResourceUserAccessStatus(BaseModel):
     user_id: StrictStr = Field(description="The ID of the user.")
     access_level: Optional[ResourceAccessLevel] = None
     status: ResourceUserAccessStatusEnum
-    expiration_date: datetime = Field(description="The day and time the user's access will expire.")
+    expiration_date: Optional[datetime] = Field(default=None, description="The day and time the user's access will expire.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["resource_id", "user_id", "access_level", "status", "expiration_date"]
 


### PR DESCRIPTION
Due to Python 3.11 strict typing, required but nullable dates in Python now don't allow `None`, this leads to errors when objects have `None` responses in their `expiration_date` fields. 

This updates the Openapi spec to remove datetimes from required if they are nullable.