### PR TITLE
[COR-1976] Add Makefile command to pull remote openapi spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ OPENAPI_GEN=openapi-generator generate --enable-post-process-file -i api/openapi
 
 gen-openapi:
 	$(OPENAPI_GEN)
+gen-openapi-remote:
+	curl https://app.opal.dev/openapi.yaml > api/openapi.yaml
+	$(OPENAPI_GEN)


### PR DESCRIPTION
Previously was not pulling remote Openapi spec for autogen, this adds a util to do so.