### PR TITLE
Add Github action to autogen SDK

### DIFF
--- a/.github/workflows/autogen-remote-changes.yml
+++ b/.github/workflows/autogen-remote-changes.yml
@@ -1,0 +1,62 @@
+name: Auto-Update SDK
+
+on:
+  schedule:
+    - cron: "0 0 * * 1" # Runs every Monday at midnight
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  update-sdk:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      run: |
+        git clone https://github.com/${{ github.repository }} repo
+        cd repo
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+    - name: Pull and generate SDK
+      run: |
+        cd repo
+        make gen-openapi-remote
+    - name: Check for changes
+      run: |
+        cd repo
+        if git diff --quiet; then
+          echo "changes=false" >> $GITHUB_ENV
+        else
+          echo "changes=true" >> $GITHUB_ENV
+        fi
+    - name: Commit changes
+      if: env.changes == 'true'
+      run: |
+        cd repo
+        git checkout -b auto-update-sdk || git checkout auto-update-sdk
+        git add .
+        git commit -m "Auto-update SDK on $(date +'%Y-%m-%d')"
+    - name: Push changes
+      if: env.changes == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd repo
+        git push --force --set-upstream origin auto-update-sdk
+    - name: Create a pull request
+      if: env.changes == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        PR_TITLE="Auto-update SDK on $(date +'%Y-%m-%d')"
+        PR_BODY="This pull request was automatically created by GitHub Actions to update the SDK."
+        curl -H "Authorization: token $GITHUB_TOKEN" \
+             -X POST \
+             -H "Content-Type: application/json" \
+             -d @- \
+             https://api.github.com/repos/${{ github.repository }}/pulls <<EOF
+                {
+                    "title": "$PR_TITLE",
+                    "body": "$PR_BODY",
+                    "head": "auto-update-sdk",
+                    "base": "main"
+                }
+                EOF

--- a/.github/workflows/autogen-remote-changes.yml
+++ b/.github/workflows/autogen-remote-changes.yml
@@ -1,64 +1,92 @@
 name: Auto-Update SDK
 
-# on:
-#   schedule:
-#     - cron: "0 0 * * 1" # Runs every Monday at midnight
-#   workflow_dispatch: # Allows manual triggering of the workflow
-
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: "0 0 * * 1" # Runs every Monday at midnight
+  workflow_dispatch: # Allows manual triggering of the workflow
 
 jobs:
   update-sdk:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
     steps:
-    - name: Checkout repository
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18' 
+    - name: Install OpenAPI Generator CLI
+      run: npm install @openapitools/openapi-generator-cli -g
+    - name: Install dependencies
       run: |
-        git clone https://github.com/${{ github.repository }} repo
-        cd repo
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
     - name: Pull and generate SDK
-      run: |
-        cd repo
-        make gen-openapi-remote
+      run: make gen-openapi-remote-for-ci
     - name: Check for changes
+      id: check_changes
       run: |
-        cd repo
         if git diff --quiet; then
           echo "changes=false" >> $GITHUB_ENV
         else
           echo "changes=true" >> $GITHUB_ENV
         fi
+    - name: Set up Git
+      if: env.changes == 'true'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
     - name: Commit changes
       if: env.changes == 'true'
       run: |
-        cd repo
-        git checkout -b auto-update-sdk || git checkout auto-update-sdk
+        BRANCH_NAME="auto-update-sdk-$(date +'%Y-%m-%d-%H-%M-%S')"
+        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+        git checkout -b $BRANCH_NAME || git checkout $BRANCH_NAME
         git add .
         git commit -m "Auto-update SDK on $(date +'%Y-%m-%d')"
     - name: Push changes
       if: env.changes == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        cd repo
-        git push --force --set-upstream origin auto-update-sdk
-    - name: Create a pull request
+      run: git push --force --set-upstream origin $BRANCH_NAME
+    - name: Install GitHub CLI
       if: env.changes == 'true'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gh
+    - name: Check for existing pull request
+      if: env.changes == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      id: check_pr
+      run: |
+        PR_EXISTS=$(gh pr list --search "Auto-update SDK" --base main --state open --json number -q '.[0].number')
+        if [[ -n "$PR_EXISTS" ]]; then
+        echo "pr_exists=true" >> $GITHUB_ENV
+        echo "PR_NUMBER=$PR_EXISTS" >> $GITHUB_ENV
+        else
+        echo "pr_exists=false" >> $GITHUB_ENV
+        fi
+    - name: Create a pull request
+      if: env.changes == 'true' && env.pr_exists == 'false'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         PR_TITLE="Auto-update SDK on $(date +'%Y-%m-%d')"
-        PR_BODY="This pull request was automatically created by GitHub Actions to update the SDK."
-        curl -H "Authorization: token $GITHUB_TOKEN" \
-             -X POST \
-             -H "Content-Type: application/json" \
-             -d @- \
-             https://api.github.com/repos/${{ github.repository }}/pulls <<EOF
-                {
-                    "title": "$PR_TITLE",
-                    "body": "$PR_BODY",
-                    "head": "auto-update-sdk",
-                    "base": "main"
-                }
-                EOF
+        PR_BODY="This pull request was automatically created by GitHub Actions to update the SDK with the latest remote OpenAPI specification."
+        gh pr create --title "$PR_TITLE" --body "$PR_BODY" --head $BRANCH_NAME --base main
+    - name: Update existing pull request
+      if: env.changes == 'true' && env.pr_exists == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "An existing pull request titled 'Auto-update SDK' is already open. Updating it with the latest changes."
+        git push --set-upstream origin $BRANCH_NAME --force
+        gh pr comment $PR_NUMBER --body "This pull request has been updated with the latest changes from the automated SDK update process on $(date +'%Y-%m-%d %H:%M:%S')."
+    

--- a/.github/workflows/autogen-remote-changes.yml
+++ b/.github/workflows/autogen-remote-changes.yml
@@ -1,9 +1,11 @@
 name: Auto-Update SDK
 
-on:
-  schedule:
-    - cron: "0 0 * * 1" # Runs every Monday at midnight
-  workflow_dispatch: # Allows manual triggering of the workflow
+# on:
+#   schedule:
+#     - cron: "0 0 * * 1" # Runs every Monday at midnight
+#   workflow_dispatch: # Allows manual triggering of the workflow
+
+on: [push, pull_request]
 
 jobs:
   update-sdk:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,9 +14,6 @@ stages:
    - pip install -r test-requirements.txt
    - pytest --cov=opal
 
-pytest-3.7:
-  extends: .pytest
-  image: python:3.7-alpine
 pytest-3.8:
   extends: .pytest
   image: python:3.8-alpine

--- a/.openapi-generator/templates/github-workflow.mustache
+++ b/.openapi-generator/templates/github-workflow.mustache
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # ref: https://docs.travis-ci.com/user/languages/python
 language: python
 python:
-  - "3.7"
   - "3.8"
   - "3.9"
   - "3.10"

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,14 @@ SHELL:=/bin/bash
 PYTHON_POST_PROCESS_FILE=python -m black
 
 OPENAPI_GEN=openapi-generator generate --enable-post-process-file -i api/openapi.yaml -g python -o . -c config.json -t .openapi-generator/templates
+OPENAPI_GEN_CI=openapi-generator-cli generate --enable-post-process-file -i api/openapi.yaml -g python -o . -c config.json -t .openapi-generator/templates
+PULL_REMOTE_OPENAPI=curl https://app.opal.dev/openapi.yaml > api/openapi.yaml
 
 gen-openapi:
 	$(OPENAPI_GEN)
 gen-openapi-remote:
-	curl https://app.opal.dev/openapi.yaml > api/openapi.yaml
+	$(PULL_REMOTE_OPENAPI)
 	$(OPENAPI_GEN)
+gen-openapi-remote-for-ci:
+	$(PULL_REMOTE_OPENAPI)
+	$(OPENAPI_GEN_CI)

--- a/config.json
+++ b/config.json
@@ -1,1 +1,8 @@
-{"enumClassPrefix": true, "packageName": "opal", "gitHost": "github.com", "gitUserId": "opalsecurity", "gitRepoId": "opal-python", "disallowAdditionalPropertiesIfNotPresent":false}
+{
+  "enumClassPrefix": true,
+  "packageName": "opal",
+  "gitHost": "github.com",
+  "gitUserId": "opalsecurity",
+  "gitRepoId": "opal-python",
+  "disallowAdditionalPropertiesIfNotPresent": false
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-urllib3 >= 1.25.3, < 2.1.0
-setuptools >= 21.0.0
-python_dateutil >= 2.5.3
+urllib3 >= 1.25.3, < 3.0.0
+python_dateutil >= 2.8.2
 pydantic >= 2
 typing-extensions >= 4.7.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
-pytest~=7.1.3
-pytest-cov>=2.8.1
-pytest-randomly>=3.12.0
-mypy>=1.4.1
-types-python-dateutil>=2.8.19
+pytest >= 7.2.1
+pytest-cov >= 2.8.1
+tox >= 3.9.0
+flake8 >= 4.0.0
+types-python-dateutil >= 2.8.19.14
+mypy >= 1.5


### PR DESCRIPTION
Github Action for autogenerating PRs with OpenAPI remote changes.

Also bumping required version to 3.8+, since `openapi-generator` doesn't support Python 3.7 anymore.

Test:
No PR existing yet:
[
![Screenshot 2024-11-26 at 2 51 31 PM](https://github.com/user-attachments/assets/7fc9c09a-d347-4f56-877e-8322cb53f263)
](url)
Updating existing open PR:
![Screenshot 2024-11-26 at 2 51 26 PM](https://github.com/user-attachments/assets/6cd5d08b-9daa-406e-a04b-d8f7d56345d4)
