### PR TITLE
[COR-1979] Add CODEOWNERS file so generated PRs have a reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+api/openapi.yaml @andrewsy-opal @giulio-opal @amruth-opal @rishikesh-opal


### PR DESCRIPTION
Add CODEOWNERS file so generated PRs have a reviewer, any time `openapi.yaml` changes