### PR TITLE
[PLAT-190] Fix autogen python sdk gha

### DIFF
--- a/.github/workflows/autogen-remote-changes.yml
+++ b/.github/workflows/autogen-remote-changes.yml
@@ -20,9 +20,9 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '18' 
+        node-version: '18'
     - name: Install OpenAPI Generator CLI
-      run: npm install @openapitools/openapi-generator-cli -g
+      run: npm install @openapitools/openapi-generator-cli@2.31.1 -g
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -32,29 +32,12 @@ jobs:
     - name: Check for changes
       id: check_changes
       run: |
-        if git diff --quiet; then
+        git add -A
+        if git diff --cached --quiet; then
           echo "changes=false" >> $GITHUB_ENV
         else
           echo "changes=true" >> $GITHUB_ENV
         fi
-    - name: Set up Git
-      if: env.changes == 'true'
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-    - name: Commit changes
-      if: env.changes == 'true'
-      run: |
-        BRANCH_NAME="auto-update-sdk-$(date +'%Y-%m-%d-%H-%M-%S')"
-        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-        git checkout -b $BRANCH_NAME || git checkout $BRANCH_NAME
-        git add .
-        git commit -m "Auto-update SDK on $(date +'%Y-%m-%d')"
-    - name: Push changes
-      if: env.changes == 'true'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: git push --force --set-upstream origin $BRANCH_NAME
     - name: Install GitHub CLI
       if: env.changes == 'true'
       run: |
@@ -66,13 +49,32 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       id: check_pr
       run: |
-        PR_EXISTS=$(gh pr list --search "Auto-update SDK" --base main --state open --json number -q '.[0].number')
+        PR_EXISTS=$(gh pr list --search "Auto-update SDK" --base main --state open --json number,headRefName -q '.[0].number')
         if [[ -n "$PR_EXISTS" ]]; then
-        echo "pr_exists=true" >> $GITHUB_ENV
-        echo "PR_NUMBER=$PR_EXISTS" >> $GITHUB_ENV
+          echo "pr_exists=true" >> $GITHUB_ENV
+          echo "PR_NUMBER=$PR_EXISTS" >> $GITHUB_ENV
+          EXISTING_BRANCH=$(gh pr list --search "Auto-update SDK" --base main --state open --json number,headRefName -q '.[0].headRefName')
+          echo "BRANCH_NAME=$EXISTING_BRANCH" >> $GITHUB_ENV
         else
-        echo "pr_exists=false" >> $GITHUB_ENV
+          echo "pr_exists=false" >> $GITHUB_ENV
+          echo "BRANCH_NAME=auto-update-sdk-$(date +'%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
         fi
+    - name: Set up Git
+      if: env.changes == 'true'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+    - name: Commit changes
+      if: env.changes == 'true'
+      run: |
+        git fetch origin || true
+        git checkout -B $BRANCH_NAME origin/$BRANCH_NAME 2>/dev/null || git checkout -B $BRANCH_NAME
+        git commit -m "Auto-update SDK on $(date +'%Y-%m-%d')"
+    - name: Push changes
+      if: env.changes == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: git push --force --set-upstream origin $BRANCH_NAME
     - name: Create a pull request
       if: env.changes == 'true' && env.pr_exists == 'false'
       env:
@@ -81,12 +83,9 @@ jobs:
         PR_TITLE="Auto-update SDK on $(date +'%Y-%m-%d')"
         PR_BODY="This pull request was automatically created by GitHub Actions to update the SDK with the latest remote OpenAPI specification."
         gh pr create --title "$PR_TITLE" --body "$PR_BODY" --head $BRANCH_NAME --base main
-    - name: Update existing pull request
+    - name: Comment on existing pull request
       if: env.changes == 'true' && env.pr_exists == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        echo "An existing pull request titled 'Auto-update SDK' is already open. Updating it with the latest changes."
-        git push --set-upstream origin $BRANCH_NAME --force
         gh pr comment $PR_NUMBER --body "This pull request has been updated with the latest changes from the automated SDK update process on $(date +'%Y-%m-%d %H:%M:%S')."
-    

--- a/openapitools.json
+++ b/openapitools.json
@@ -2,6 +2,6 @@
   "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.10.0"
+    "version": "7.19.0"
   }
 }


### PR DESCRIPTION
current workflow had some bugs

1. `git diff --quiet` only checks tracked files so new generated files were getting dropped. Fixed this by adding `git add -A`
2. reruns didn't actually update the PR since it created a new branch, but the PR still points to the original branch. Updated the action to actually update the existing branch.
3. `openapi-generator-cli` wasn't pinned to a stable version


Ran the workflow using my branch [here](https://github.com/opalsecurity/opal-python/actions/runs/24752510056) which produced [this pr](https://github.com/opalsecurity/opal-python/pull/42/changes)