### PR TITLE
[PLAT-193] Fix python sdk publish to pypi gha

### DIFF
--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          fetch-tags: true
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opal_security"
-version = "1.0.0"
+dynamic = ["version"]
 description = "Opal API"
 authors = [
   {name = "Opal Team",email = "hello@opal.dev"},
@@ -32,7 +32,7 @@ mypy = ">= 1.5"
 
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.pylint.'MESSAGES CONTROL']


### PR DESCRIPTION
The publish to pypi workflow was silently broken and attempts to publish every release as 1.0.0 which gets skipped since it already exists.

The OpenAPI generator upgrade from 7.10.0 to 7.19.0 changed the pyproject.toml format from [tool.poetry] to the standard [project] table which causes the hardcoded `version = "1.0.0"` to override the old versioning logic.

See workflow run here https://github.com/opalsecurity/opal-python/actions/runs/24752948149/job/72419853149

This replaces that hardcoded `version = "1.0.0"` to `["version"]`. This also updates the workflow to specify `fetch-tags: true` in the checkout so the workflow can use the git tag for the version.

Tested this locally to confirm that new builds use the existing tag