### PR TITLE
[PLAT-193] Fix python sdk publish to pypi - part 2

### DIFF
--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -9,9 +9,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-          fetch-tags: true
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
actions/checkout@3 fails when trying to do fetch-tags: true with fetch-depth: 1
https://github.com/opalsecurity/opal-python/actions/runs/24754632364/job/72425115056

I just took this out since I don't think this needs to fetch all the tags.